### PR TITLE
sdsfree everything before return'ing

### DIFF
--- a/src/amnuts230.c
+++ b/src/amnuts230.c
@@ -4030,6 +4030,7 @@ dump_commands(int sig)
     filename = sdscatfmt(sdsempty(), "%s/%s.%s", LOGFILES, LAST_CMD, dstr);
     fp = fopen(filename, "w");
     if (!fp) {
+        sdsfree(filename);
         return;
     }
     fprintf(fp, "Caught signal %d:\n\n", sig);
@@ -4303,6 +4304,7 @@ add_history(char *username, int showtime, const char *str, ...)
     filename = sdscatfmt(sdsempty(), "%s/%s/%s.H", USERFILES, USERHISTORYS, username);
     fp = fopen(filename, "a");
     if (!fp) {
+        sdsfree(filename);
         return;
     }
     time(&now);


### PR DESCRIPTION
1970df3b86105c8f9574ba2e8cac687f77efce0b introduces some sds uses,
and they all seem alright. However, in two cases, they are in
situations where there's a code path that meets a 'return'. In
those cases, sdsfree must be called before return.