### PR TITLE
Add missing comment closing mark

### DIFF
--- a/src/includes/netlinks.h
+++ b/src/includes/netlinks.h
@@ -8,7 +8,7 @@
 
    NUTS version 3.3.3 (Triple Three :) - Copyright (C) Neil Robertson 1996
 
- ***************************************************************************
+ ***************************************************************************/
 
 #ifndef AMNUTS_NETLINKS_H
 #define AMNUTS_NETLINKS_H

--- a/src/includes/rooms.h
+++ b/src/includes/rooms.h
@@ -8,7 +8,7 @@
 
    NUTS version 3.3.3 (Triple Three :) - Copyright (C) Neil Robertson 1996
 
- ***************************************************************************
+ ***************************************************************************/
 
 #ifndef AMNUTS_ROOMS_H
 #define AMNUTS_ROOMS_H


### PR DESCRIPTION
I had to add a comment closing mark to the end of multi-line comments.

Compilation fails with error otherwise:

```
$ make
Compiling talker /Amnuts/src/netlinks.c ... (/Amnuts/src/objects/netlinks.o)
gcc -g -Wall -W -MMD -I/Amnuts/src/includes -DGAMES -DWIZPORT -DIDENTD -DMANDNS -DNETLINKS -c -o /Amnuts/src/objects/netlinks.o /Amnuts/src/netlinks.c
In file included from /Amnuts/src/netlinks.c:24:
/Amnuts/src/includes/netlinks.h:61:2: error: #endif without #if
   61 | #endif
      |  ^~~~~
make: *** [Makefile:118: /Amnuts/src/objects/netlinks.o] Error 1
```

```
$ make
Compiling talker /Amnuts/src/rooms.c ... (/Amnuts/src/objects/rooms.o)
gcc -g -Wall -W -MMD -I/Amnuts/src/includes -DGAMES -DWIZPORT -DIDENTD -DMANDNS -DNETLINKS -c -o /Amnuts/src/objects/rooms.o /Amnuts/src/rooms.c
In file included from /Amnuts/src/rooms.c:16:
/Amnuts/src/includes/rooms.h:26:38: error: array type has incomplete element type ‘struct priv_room_struct’
   26 | static const struct priv_room_struct priv_room[] = {
      |                                      ^~~~~~~~~
/Amnuts/src/includes/rooms.h:32:2: error: #endif without #if
   32 | #endif
      |  ^~~~~
make: *** [Makefile:118: /Amnuts/src/objects/rooms.o] Error 1
```