### PR TITLE
make all new users equal in their in and out messages

### DIFF
--- a/files/userfiles/Identduser.D
+++ b/files/userfiles/Identduser.D
@@ -10,7 +10,7 @@ purging       1
 last_site     127.0.0.1 (no
 mail_verify   #UNSET
 description   is a newbie needing a desc.
-in_phrase     wanders in.
+in_phrase     wanders in
 out_phrase    wanders out
 email         #UNSET
 homepage      #UNSET

--- a/src/commands/account.c
+++ b/src/commands/account.c
@@ -71,8 +71,8 @@ create_account(UR_OBJECT user)
         strcpy(u->pass, crypt(word[2], crypt_salt));
         strcpy(u->recap, u->name);
         strcpy(u->desc, "is a newbie");
-        strcpy(u->in_phrase, "wanders in.");
-        strcpy(u->out_phrase, "wanders out");
+        strcpy(u->in_phrase, "enters");
+        strcpy(u->out_phrase, "goes");
         strcpy(u->last_site, "created_account");
         strcpy(u->site, u->last_site);
         strcpy(u->logout_room, "<none>");


### PR DESCRIPTION
When a new user registers, by default its inmsg is "enters" and its outmsg is "goes". However, it is possible to distinguish characters created that way from those created by .create because in the latter case, their default message is "wanders in." or "wanders out".

This patch changes the .in and .out messages on .created users, so they all look the same. Furthermore, "wanders in." should not have the closing period (as the code adds it on its own), and so this patch also removes Identduser's inmsg to remove that extra dot.